### PR TITLE
Add logic to support customized granularity

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,9 @@ sudo ./bazel-bin/flashroute/flashroute --interface eth0 --probing_rate 10000 --o
 
 ## Flags
 
-`--split_ttl` Specify initial TTL to start Scan. By default, 16
+`--split_ttl` Specify initial TTL to start Scan. By default, 16.
+
+`--granularity` Specify the granularity of the scan. For example, if this value is set to 24, FlashRoute will scan one address per /24 prefix. The range of this value is [1, 32]. By default, 24. Caveat: this value will affect the memory footprint and the network probes and time usage of a scan.
 
 `--preprobing` Enable optimization to use preprobing measure hop distance first. By default, enabled.
 

--- a/flashroute/main.cc
+++ b/flashroute/main.cc
@@ -127,6 +127,8 @@ void printFlags() {
                    (absl::GetFlag(FLAGS_sequential_scan) ? "true" : "false");
   VLOG(1) << boost::format("Probing rate: %|30t|%1% Packet Per Second") %
                    absl::GetFlag(FLAGS_probing_rate);
+  VLOG(1) << boost::format("Scan granularity: %|30t|%1%") %
+                   absl::GetFlag(FLAGS_granularity);
   VLOG(1) << boost::format("Preprobing: %|30t|%1%") %
                    (absl::GetFlag(FLAGS_preprobing) ? "true" : "false");
   VLOG(1) << boost::format("Forward probing: %|30t|%1%") %

--- a/flashroute/main.cc
+++ b/flashroute/main.cc
@@ -31,6 +31,10 @@ ABSL_FLAG(std::string, dump_targets_file, "", "Dump targets to file.");
 
 
 ABSL_FLAG(int16_t, split_ttl, 16, "Default split ttl.");
+ABSL_FLAG(
+    int16_t, granularity, 24,
+    "The granularity of scan; that is, scan pick 1 address per the given "
+    "length of prefix. The range of this value is [1, 32]. By default, 24.");
 
 ABSL_FLAG(std::string, interface, "", "Relay Interface.");
 ABSL_FLAG(int32_t, probing_rate, 400000, "Probing rate.");
@@ -200,7 +204,8 @@ int main(int argc, char* argv[]) {
         absl::GetFlag(FLAGS_dst_port),
         absl::GetFlag(FLAGS_default_payload_message),
         absl::GetFlag(FLAGS_probing_rate), absl::GetFlag(FLAGS_output),
-        absl::GetFlag(FLAGS_encode_timestamp));
+        absl::GetFlag(FLAGS_encode_timestamp),
+        static_cast<uint8_t>(absl::GetFlag(FLAGS_granularity)));
 
     Tracerouter& traceRouter = *traceRouterPtr.get();
 

--- a/flashroute/traceroute.h
+++ b/flashroute/traceroute.h
@@ -51,8 +51,10 @@ enum class ProbePhase { PREPROBE, PROBE, NONE };
  *                                // probe.   
  *    10000,                      // Set probing rate. 
  *    "./output.dat",             // Set the output filepath.
- *    true                        // Control whether to encode timestamp to each
- *                                // probe. (Test function)
+ *    true,                       // Control whether to encode timestamp to each
+ *                                // probe. (Test function).
+ *    24                          // Granularity of scan. (One address per /24
+ *                                // prefix)
  * );
  * 
  * // startScan accepts two parameters:
@@ -79,7 +81,8 @@ class Tracerouter {
               const uint16_t srcPort, const uint16_t dstPort,
               const std::string& defaultPayloadMessage,
               const int64_t probingRate, const std::string& resultFilepath,
-              const bool encodeTimestamp);
+              const bool encodeTimestamp,
+              const uint8_t granularity);
 
   ~Tracerouter();
 
@@ -139,6 +142,10 @@ class Tracerouter {
 
   std::unique_ptr<UdpProber> prober_;
   std::unique_ptr<NetworkManager> networkManager_;
+
+  // The scan granularity, which decides one address per /24, /25, or /26
+  // prefix.
+  uint8_t granularity_;
 
   // The default max ttl which is also the starting hop-distance of probing.
   uint8_t defaultSplitTTL_;


### PR DESCRIPTION
Now, FlashRoute only supports scan over one address per /24 prefix. This change allows FlashRoute to customize the scan granularity.