### PR TITLE
Add ttl offset support

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,15 +85,15 @@ Bazel is an open-source build system, developed by Google and widely adopted by 
 
 Bazel supports [ different installation methods ](https://docs.bazel.build/versions/master/install-ubuntu.html).
 
-This example provides the installation of Bazel 2.0.0, but you can freely replace the version to whatever the version you like to install.
-FlashRoute can be built by Bazel from 0.x to 3.2 on x86_64 machines.
+This example provides the installation of Bazel 3.7.2, but you can freely replace the version to whatever the version you like to install.
+FlashRoute can be built by Bazel from 0.x to 3.7 on x86_64 machines.
 However, for Arm users, **Bazel 2.1.1 is recommended**.
 
 ```
-wget https://github.com/bazelbuild/bazel/releases/download/2.0.0/bazel-2.0.0-installer-linux-x86_64.sh
+wget https://github.com/bazelbuild/bazel/releases/download/3.7.2/bazel-3.7.2-installer-linux-x86_64.sh
 
-chmod +x bazel-2.0.0-installer-linux-x86_64.sh
-./bazel-2.0.0-installer-linux-x86_64.sh --user
+chmod +x bazel-3.7.2-installer-linux-x86_64.sh
+./bazel-3.7.2-installer-linux-x86_64.sh --user
 export PATH="$PATH:$HOME/bin"
 export BAZEL_CXXOPTS="-std=c++14" 
 ```

--- a/flashroute/main.cc
+++ b/flashroute/main.cc
@@ -34,6 +34,10 @@ ABSL_FLAG(std::string, dump_targets_file, "", "Dump targets to file.");
 ABSL_FLAG(std::string, prober_type, "udp",
           "The prober used for the scan. Options: udp, udp idempotent");
 
+ABSL_FLAG(int16_t, ttl_offset, 0,
+          "Offset of ttl. For example, if offset is 5, the scan will cover the "
+          "ttl in thhe range [6, 38].");
+
 ABSL_FLAG(int16_t, split_ttl, 16, "Default split ttl.");
 ABSL_FLAG(
     int16_t, granularity, 24,
@@ -258,7 +262,7 @@ int main(int argc, char* argv[]) {
         absl::GetFlag(FLAGS_proximity_span), absl::GetFlag(FLAGS_scan_count),
         absl::GetFlag(FLAGS_src_port), absl::GetFlag(FLAGS_dst_port),
         absl::GetFlag(FLAGS_default_payload_message),
-        absl::GetFlag(FLAGS_encode_timestamp));
+        absl::GetFlag(FLAGS_encode_timestamp), absl::GetFlag(FLAGS_ttl_offset));
     traceRouterPtr = &traceRouter;
 
     // Load hitlist.
@@ -289,7 +293,8 @@ int main(int argc, char* argv[]) {
 
     printFlags();
   } else {
-    SingleHost tracerouter(0, absl::GetFlag(FLAGS_dst_port));
+    SingleHost tracerouter(0, absl::GetFlag(FLAGS_dst_port),
+                           absl::GetFlag(FLAGS_ttl_offset));
     tracerouter.startScan(target, finalInterface);
   }
   LOG(INFO) << "The program ends.";

--- a/flashroute/network.cc
+++ b/flashroute/network.cc
@@ -56,6 +56,7 @@ NetworkManager::NetworkManager(Prober* prober, const std::string& interface,
 }
 
 NetworkManager::~NetworkManager() {
+  stopListening();
   close(sendingSocket_);
 }
 

--- a/flashroute/single_host.cc
+++ b/flashroute/single_host.cc
@@ -46,7 +46,8 @@ void SingleHost::startScan(const std::string& target,
     prober = new UdpProber(&response_handler, 0, 0, dstPort_, "test", true,
                            ttlOffset_);
   } else {
-    prober = new UdpProberIpv6(&response_handler, 0, 0, dstPort_, "test");
+    prober = new UdpProberIpv6(&response_handler, 0, 0, dstPort_, "test",
+                               ttlOffset_);
   }
   NetworkManager networkManager(prober, interface, 100, remoteHost->isIpv4());
   networkManager.startListening();

--- a/flashroute/single_host.cc
+++ b/flashroute/single_host.cc
@@ -13,8 +13,9 @@
 
 namespace flashroute {
 
-SingleHost::SingleHost(const uint16_t srcPort, const uint16_t dstPort)
-    : srcPort_(srcPort), dstPort_(dstPort) {
+SingleHost::SingleHost(const uint16_t srcPort, const uint16_t dstPort,
+                       const uint8_t ttlOffset)
+    : srcPort_(srcPort), dstPort_(dstPort), ttlOffset_(ttlOffset) {
   results_ = new std::unordered_map<
       uint8_t, std::tuple<std::shared_ptr<IpAddress>, uint32_t>>();
 }
@@ -42,7 +43,8 @@ void SingleHost::startScan(const std::string& target,
 
   Prober* prober;
   if (remoteHost->isIpv4()) {
-    prober = new UdpProber(&response_handler, 0, 0, dstPort_, "test", true);
+    prober = new UdpProber(&response_handler, 0, 0, dstPort_, "test", true,
+                           ttlOffset_);
   } else {
     prober = new UdpProberIpv6(&response_handler, 0, 0, dstPort_, "test");
   }
@@ -55,7 +57,7 @@ void SingleHost::startScan(const std::string& target,
 
   sleep(3);
 
-  for (uint8_t i = 1; i <= 32; i++) {
+  for (uint8_t i = 1 + ttlOffset_; i <= 32 + ttlOffset_; i++) {
     if (results_->find(i) == results_->end()) {
       LOG(INFO) << boost::format("%1% %|5t|*") % static_cast<int>(i);
     } else {

--- a/flashroute/single_host.h
+++ b/flashroute/single_host.h
@@ -14,7 +14,8 @@ namespace flashroute {
 
 class SingleHost {
  public:
-  SingleHost(const uint16_t srcPort, const uint16_t dstPort);
+  SingleHost(const uint16_t srcPort, const uint16_t dstPort,
+             const uint8_t ttlOffset);
 
   ~SingleHost();
 
@@ -28,6 +29,7 @@ class SingleHost {
  private:
   uint16_t srcPort_;
   uint16_t dstPort_;
+  uint8_t ttlOffset_;
 
   std::unordered_map<uint8_t, std::tuple<std::shared_ptr<IpAddress>, uint32_t>>*
       results_;

--- a/flashroute/traceroute.cc
+++ b/flashroute/traceroute.cc
@@ -57,7 +57,8 @@ Tracerouter::Tracerouter(
     const bool preprobing, const bool preprobingPrediction,
     const int32_t predictionProximitySpan, const int32_t scanCount,
     const uint16_t srcPort, const uint16_t dstPort,
-    const std::string& defaultPayloadMessage, const bool encodeTimestamp)
+    const std::string& defaultPayloadMessage, const bool encodeTimestamp,
+    const uint8_t ttlOffset)
     : dcbManager_(dcbManager),
       stopProbing_(false),
       probePhase_(ProbePhase::NONE),
@@ -65,6 +66,7 @@ Tracerouter::Tracerouter(
       networkManager_(networkManager),
       defaultSplitTTL_(defaultSplitTTL),
       defaultPreprobingTTL_(defaultPreprobingTTL),
+      ttlOffset_(ttlOffset),
       forwardProbingMark_(forwardProbing),
       forwardProbingGapLimit_(forwardProbingGapLimit),
       redundancyRemovalMark_(redundancyRemoval),
@@ -215,9 +217,9 @@ void Tracerouter::startPreprobing(ProberType proberType, bool ipv4) {
 
   if (proberType == ProberType::UDP_PROBER) {
     if (ipv4) {
-      prober_ =
-          std::make_unique<UdpProber>(&callback, 0, kPreProbePhase, dstPort_,
-                                      defaultPayloadMessage_, encodeTimestamp_);
+      prober_ = std::make_unique<UdpProber>(&callback, 0, kPreProbePhase,
+                                            dstPort_, defaultPayloadMessage_,
+                                            encodeTimestamp_, ttlOffset_);
     } else {
       prober_ = std::make_unique<UdpProberIpv6>(
           &callback, 0, kPreProbePhase, dstPort_, defaultPayloadMessage_);
@@ -275,9 +277,9 @@ void Tracerouter::startProbing(ProberType proberType, bool ipv4) {
 
   if (proberType == ProberType::UDP_PROBER) {
     if (ipv4) {
-      prober_ =
-          std::make_unique<UdpProber>(&callback, 0, kMainProbePhase, dstPort_,
-                                      defaultPayloadMessage_, encodeTimestamp_);
+      prober_ = std::make_unique<UdpProber>(&callback, 0, kMainProbePhase,
+                                            dstPort_, defaultPayloadMessage_,
+                                            encodeTimestamp_, ttlOffset_);
 
     } else {
       prober_ = std::make_unique<UdpProberIpv6>(

--- a/flashroute/traceroute.cc
+++ b/flashroute/traceroute.cc
@@ -222,12 +222,13 @@ void Tracerouter::startPreprobing(ProberType proberType, bool ipv4) {
                                             encodeTimestamp_, ttlOffset_);
     } else {
       prober_ = std::make_unique<UdpProberIpv6>(
-          &callback, 0, kPreProbePhase, dstPort_, defaultPayloadMessage_);
+          &callback, 0, kPreProbePhase, dstPort_, defaultPayloadMessage_,
+          ttlOffset_);
     }
   } else if (proberType == ProberType::UDP_IDEMPOTENT_PROBER) {
     prober_ = std::make_unique<UdpIdempotentProber>(
         &callback, 0, kPreProbePhase, dstPort_, defaultPayloadMessage_,
-        encodeTimestamp_);
+        encodeTimestamp_, ttlOffset_);
   } else {
     LOG(FATAL) << "Error in creating prober.";
   }
@@ -283,12 +284,13 @@ void Tracerouter::startProbing(ProberType proberType, bool ipv4) {
 
     } else {
       prober_ = std::make_unique<UdpProberIpv6>(
-          &callback, 0, kPreProbePhase, dstPort_, defaultPayloadMessage_);
+          &callback, 0, kPreProbePhase, dstPort_, defaultPayloadMessage_,
+          ttlOffset_);
     }
   } else if (proberType == ProberType::UDP_IDEMPOTENT_PROBER) {
     prober_ = std::make_unique<UdpIdempotentProber>(
         &callback, 0, kMainProbePhase, dstPort_, defaultPayloadMessage_,
-        encodeTimestamp_);
+        encodeTimestamp_, ttlOffset_);
   } else {
     LOG(FATAL) << "Error in creating prober.";
   }

--- a/flashroute/traceroute.h
+++ b/flashroute/traceroute.h
@@ -53,8 +53,9 @@ enum class ProberType { UDP_PROBER, UDP_IDEMPOTENT_PROBER };
  *    53,                         // Set the expected destination port.
  *    "test",                     // Message to encode into the payload of each
  *                                // probe.   
- *    true)                       // Control whether to encode timestamp to each
+ *    true,                       // Control whether to encode timestamp to each
  *                                // probe. (Test function).
+ *    0)                          // ttl offset to shift the range of ttl
  * );
  * 
  * // startScan accepts two parameters:
@@ -80,7 +81,7 @@ class Tracerouter {
               const int32_t predictionProximitySpan, const int32_t scanCount,
               const uint16_t srcPort, const uint16_t dstPort,
               const std::string& defaultPayloadMessage,
-              const bool encodeTimestamp);
+              const bool encodeTimestamp, const uint8_t ttlOffset);
 
   ~Tracerouter();
 
@@ -108,6 +109,9 @@ class Tracerouter {
 
   // The ttl to preprobe targets.
   uint8_t defaultPreprobingTTL_;
+
+  // The offset of ttl.
+  uint8_t ttlOffset_;
 
   // Control whether or not to forward probe. Per our design, we can forward
   // probe the router interfaces at a hop-distance further if tailing N nodes

--- a/flashroute/udp_idempotent_prober.h
+++ b/flashroute/udp_idempotent_prober.h
@@ -50,7 +50,7 @@ class UdpIdempotentProber : public virtual Prober {
                       const uint8_t probePhaseCode,
                       const uint16_t destinationPort,
                       const std::string& payloadMessage,
-                      const bool encodeTimestamp);
+                      const bool encodeTimestamp, const uint8_t ttlOffset);
 
   // Construct probe.
   size_t packProbe(const IpAddress& destinationIp, const IpAddress& sourceIp,
@@ -73,6 +73,7 @@ class UdpIdempotentProber : public virtual Prober {
   int32_t checksumOffset_;
   uint8_t probePhaseCode_;
   uint16_t destinationPort_;
+  uint8_t ttlOffset_;
   std::string payloadMessage_;
   bool encodeTimestamp_;
 

--- a/flashroute/udp_prober.cc
+++ b/flashroute/udp_prober.cc
@@ -176,8 +176,9 @@ void UdpProber::parseResponse(uint8_t* buffer, size_t size,
                                        kTimestampSlot) %
                  kTimestampSlot;
 
-  int16_t initialTTL = static_cast<int16_t>(probeIpId & 0x1F) + ttlOffset_;
+  int16_t initialTTL = static_cast<int16_t>(probeIpId & 0x1F);
   if (initialTTL == 0) initialTTL = 32;
+  initialTTL += ttlOffset_;
 
   if (parsedPacket->icmp.icmp_type == 3 &&
       (parsedPacket->icmp.icmp_code == 3 || parsedPacket->icmp.icmp_code == 2 ||
@@ -202,7 +203,7 @@ void UdpProber::parseResponse(uint8_t* buffer, size_t size,
     return;
   }
 
-  if (distance <= ttlOffset_ || distance > kMaxTtl + ttlOffset_) {
+  if (distance <= ttlOffset_ || distance > (kMaxTtl + ttlOffset_)) {
     distanceAbnormalities_ += 1;
     return;
   }

--- a/flashroute/udp_prober.cc
+++ b/flashroute/udp_prober.cc
@@ -23,13 +23,14 @@ UdpProber::UdpProber(PacketReceiverCallback* callback,
                      const int32_t checksumOffset, const uint8_t probePhaseCode,
                      const uint16_t destinationPort,
                      const std::string& payloadMessage,
-                     const bool encodeTimestamp) {
+                     const bool encodeTimestamp, const uint8_t ttlOffset) {
   probePhaseCode_ = probePhaseCode;
   callback_ = callback;
   checksumOffset_ = checksumOffset;
   payloadMessage_ = payloadMessage;
   destinationPort_ = htons(destinationPort);
   encodeTimestamp_ = encodeTimestamp;
+  ttlOffset_ = ttlOffset;
   checksumMismatches_ = 0;
   distanceAbnormalities_ = 0;
   otherMismatches_ = 0;
@@ -57,7 +58,7 @@ size_t UdpProber::packProbe(const IpAddress& destinationIp,
       *(reinterpret_cast<struct in_addr*>(&destinationIpDecimal));
   packet->ip.ip_src = *(reinterpret_cast<struct in_addr*>(&sourceIpDecimal));
   packet->ip.ip_p = kUdpProtocol;  // UDP protocol
-  packet->ip.ip_ttl = ttl;
+  packet->ip.ip_ttl = ttl + ttlOffset_;
   // ipid: 5-bit for encoding intiial TTL, 1 bit for encoding probeType, 10-bit
   // for encoding timestamp.
   // 0x3FF = 2^10 to extract first 10-bit of timestamp
@@ -175,7 +176,7 @@ void UdpProber::parseResponse(uint8_t* buffer, size_t size,
                                        kTimestampSlot) %
                  kTimestampSlot;
 
-  int16_t initialTTL = static_cast<int16_t>(probeIpId & 0x1F);
+  int16_t initialTTL = static_cast<int16_t>(probeIpId & 0x1F) + ttlOffset_;
   if (initialTTL == 0) initialTTL = 32;
 
   if (parsedPacket->icmp.icmp_type == 3 &&
@@ -201,7 +202,7 @@ void UdpProber::parseResponse(uint8_t* buffer, size_t size,
     return;
   }
 
-  if (distance <= 0 || distance > kMaxTtl) {
+  if (distance <= ttlOffset_ || distance > kMaxTtl + ttlOffset_) {
     distanceAbnormalities_ += 1;
     return;
   }

--- a/flashroute/udp_prober.h
+++ b/flashroute/udp_prober.h
@@ -48,7 +48,8 @@ class UdpProber : public virtual Prober {
  public:
   UdpProber(PacketReceiverCallback* callback, const int32_t checksumOffset,
             const uint8_t probePhaseCode, const uint16_t destinationPort,
-            const std::string& payloadMessage, const bool encodeTimestamp);
+            const std::string& payloadMessage, const bool encodeTimestamp,
+            const uint8_t ttlOffset);
 
   // Construct probe.
   size_t packProbe(const IpAddress& destinationIp, const IpAddress& sourceIp,
@@ -80,8 +81,9 @@ class UdpProber : public virtual Prober {
  private:
   PacketReceiverCallback* callback_;
   int32_t checksumOffset_;
-  uint8_t probePhaseCode_;
   uint16_t destinationPort_;
+  uint8_t probePhaseCode_;
+  uint8_t ttlOffset_;
   std::string payloadMessage_;
   bool encodeTimestamp_;
 

--- a/flashroute/udp_prober_v6.h
+++ b/flashroute/udp_prober_v6.h
@@ -70,7 +70,7 @@ class UdpProberIpv6 : public virtual Prober {
  public:
   UdpProberIpv6(PacketReceiverCallback* callback, const int32_t checksumOffset,
                 const uint8_t probePhaseCode, const uint16_t destinationPort,
-                const std::string& payloadMessage);
+                const std::string& payloadMessage, const uint8_t ttlOffset);
 
   // Construct probe.
   size_t packProbe(const IpAddress& destinationIp, const IpAddress& sourceIp,
@@ -96,6 +96,7 @@ class UdpProberIpv6 : public virtual Prober {
   PacketReceiverCallback* callback_;
   int32_t checksumOffset_;
   uint8_t probePhaseCode_;
+  uint8_t ttlOffset_;
   uint16_t destinationPort_;
   std::string payloadMessage_;
   bool encodeTimestamp_;


### PR DESCRIPTION
Originally, FlashRoute can only scan TTL in range [1, 32]. This change adds ttl_offset support to allow FlashRoute scan a customized range of TTL, for example, [2, 33] or [6, 37] by setting initial TTL offset.
