### PR TITLE
WORKSPACE: update nelhage/rules_boost and abseil/abseil-cpp

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -37,9 +37,9 @@ go_repository(
 
 git_repository(
     name = "com_github_nelhage_rules_boost",
-    commit = "9f9fb8b2f0213989247c9d5c0e814a8451d18d7f",
+    commit = "fb9f3c9a6011f966200027843d894923ebc9cd0b",
     remote = "https://github.com/nelhage/rules_boost",
-    shallow_since = "1570056263 -0700",
+    shallow_since = "1626494016 -0700",
 )
 
 load("@com_github_nelhage_rules_boost//:boost/boost.bzl", "boost_deps")
@@ -47,9 +47,9 @@ boost_deps()
 
 git_repository(
     name = "com_google_absl",
-    commit = "6df644c56f31b100bf731e27c3825069745651e3",
+    commit = "278e0a071885a22dcd2fd1b5576cc44757299343",
     remote = "https://github.com/abseil/abseil-cpp.git",
-    shallow_since = "1608147541 -0500",
+    shallow_since = "1622559169 -0400",
 )
 
 new_git_repository(


### PR DESCRIPTION
Hi,

This fixes two issues that prevents FlashRoute from building on ARM64.

```
ERROR: /root/.cache/bazel/_bazel_root/4113155584afb855b97913f42db88493/external/boost/BUILD.bazel:1583:14: Configurable attribute "defines" doesn't match this configuration (would a default condition help?).
```
Fixed by upgrading to the latest commit of nelhage/rules_boost, which includes https://github.com/nelhage/rules_boost/pull/168.

```
In file included from external/com_google_absl/absl/random/internal/randen_hwaes.cc:229:
/usr/lib/gcc/aarch64-linux-gnu/9/include/arm_neon.h: In function 'Vector128 {anonymous}::AesRound(const Vector128&, const Vector128&)':
/usr/lib/gcc/aarch64-linux-gnu/9/include/arm_neon.h:12452:1: error: inlining failed in call to always_inline 'uint8x16_t vaesmcq_u8(uint8x16_t)': target specific option mismatch
12452 | vaesmcq_u8 (uint8x16_t data)
      | ^~~~~~~~~~
```
Fixed by upgrading to [Abseil LTS March 2021](https://github.com/abseil/abseil-cpp/releases/tag/20210324.2).